### PR TITLE
Add deterministic CV AI pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ backend/data/logs/logs.log.*
 backend/data/logs/logs.log.*.*
 backend/data/logs/logs.log.*.*.*
 backend/data/logs/logs.log.*.*.*.*
+backend/dist
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -2,11 +2,10 @@
   "name": "backend",
   "version": "1.2508.101530",
   "description": "CV Builder backend",
-  "main": "index.js",
+  "main": "dist/server.js",
   "scripts": {
-    "start": "node index.js",
-    "dev": "node index.js",
-    "dev:watch": "nodemon index.js"
+    "build": "tsc",
+    "start": "node dist/server.js"
   },
   "keywords": [],
   "author": "Mustafa Evleksiz",
@@ -35,6 +34,9 @@
     "zod": "^4.0.16"
   },
   "devDependencies": {
-    "nodemon": "^3.1.4"
+    "nodemon": "^3.1.4",
+    "typescript": "^5.4.5",
+    "@types/express": "^4.17.21",
+    "@types/cors": "^2.8.15"
   }
 }

--- a/backend/src/pipeline.ts
+++ b/backend/src/pipeline.ts
@@ -1,0 +1,83 @@
+import OpenAI from 'openai';
+import { PipelineRequest, Extraction, GapAnalysis, Questions, BulletRewrite, Score, ExtractionSchema, GapAnalysisSchema, QuestionsSchema, BulletRewriteSchema, ScoreSchema, PipelineResponse, PipelineResponseSchema } from './schemas';
+
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+async function extract({ cvText, template }: PipelineRequest): Promise<Extraction> {
+  const prompt = `Extract the following CV text into JSON matching this template: ${JSON.stringify(template)}. Return only JSON.`;
+  const resp = await openai.chat.completions.create({
+    model: 'gpt-4o-mini',
+    temperature: 0,
+    messages: [{ role: 'user', content: prompt }],
+    response_format: { type: 'json_object' },
+  });
+  const content = resp.choices[0].message.content ?? '{}';
+  return ExtractionSchema.parse(JSON.parse(content));
+}
+
+async function gapAnalysis(cv: Extraction, appLanguage: string): Promise<GapAnalysis> {
+  const prompt = `Identify missing or weak sections in this CV JSON. Respond with {"gaps":[]}. CV:${JSON.stringify(cv)}`;
+  const resp = await openai.chat.completions.create({
+    model: 'gpt-4o-mini',
+    temperature: 0,
+    messages: [{ role: 'user', content: prompt }],
+    response_format: { type: 'json_object' },
+  });
+  const content = resp.choices[0].message.content ?? '{}';
+  return GapAnalysisSchema.parse(JSON.parse(content));
+}
+
+async function targetedQuestions(cv: Extraction, gaps: GapAnalysis, appLanguage: string): Promise<Questions> {
+  const prompt = `Based on CV JSON and its gaps, ask up to 5 questions to fill the gaps. Respond with {"questions":[]}. CV:${JSON.stringify(cv)} GAPS:${JSON.stringify(gaps.gaps)}`;
+  const resp = await openai.chat.completions.create({
+    model: 'gpt-4o-mini',
+    temperature: 0,
+    messages: [{ role: 'user', content: prompt }],
+    response_format: { type: 'json_object' },
+  });
+  const content = resp.choices[0].message.content ?? '{}';
+  return QuestionsSchema.parse(JSON.parse(content));
+}
+
+function collectBullets(cv: Extraction): string[] {
+  const bullets: string[] = [];
+  const experience = (cv as any).experience as any[] | undefined;
+  experience?.forEach(exp => {
+    if (Array.isArray(exp?.bullets)) bullets.push(...exp.bullets.filter((b: unknown): b is string => typeof b === 'string'));
+  });
+  return bullets;
+}
+
+async function rewriteBullets(cv: Extraction): Promise<BulletRewrite> {
+  const bullets = collectBullets(cv);
+  const prompt = `Rewrite each bullet to be concise and action-oriented. Return {"bullets":[]}. BULLETS:${JSON.stringify(bullets)}`;
+  const resp = await openai.chat.completions.create({
+    model: 'gpt-4o-mini',
+    temperature: 0,
+    messages: [{ role: 'user', content: prompt }],
+    response_format: { type: 'json_object' },
+  });
+  const content = resp.choices[0].message.content ?? '{}';
+  return BulletRewriteSchema.parse(JSON.parse(content));
+}
+
+async function scoreCv(cv: Extraction, appLanguage: string): Promise<Score> {
+  const prompt = `Score this CV from 0-100 and provide short comment in ${appLanguage}. Return {"score":number,"comment":string}. CV:${JSON.stringify(cv)}`;
+  const resp = await openai.chat.completions.create({
+    model: 'gpt-4o-mini',
+    temperature: 0,
+    messages: [{ role: 'user', content: prompt }],
+    response_format: { type: 'json_object' },
+  });
+  const content = resp.choices[0].message.content ?? '{}';
+  return ScoreSchema.parse(JSON.parse(content));
+}
+
+export async function runPipeline(req: PipelineRequest): Promise<PipelineResponse> {
+  const extracted = await extract(req);
+  const gaps = await gapAnalysis(extracted, req.appLanguage);
+  const questions = await targetedQuestions(extracted, gaps, req.appLanguage);
+  const rewritten = await rewriteBullets(extracted);
+  const score = await scoreCv(extracted, req.appLanguage);
+  return PipelineResponseSchema.parse({ extracted, gaps, questions, rewritten, score });
+}

--- a/backend/src/routes/pipeline.ts
+++ b/backend/src/routes/pipeline.ts
@@ -1,0 +1,23 @@
+import { Router } from 'express';
+import rateLimit from 'express-rate-limit';
+import { PipelineRequestSchema } from '../schemas';
+import { runPipeline } from '../pipeline';
+
+const router = Router();
+const limiter = rateLimit({ windowMs: 60_000, max: 5 });
+
+router.post('/pipeline', limiter, async (req, res) => {
+  const parsed = PipelineRequestSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: 'Invalid request', details: parsed.error.format() });
+  }
+  try {
+    const result = await runPipeline(parsed.data);
+    res.json(result);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Pipeline failed' });
+  }
+});
+
+export default router;

--- a/backend/src/schemas.ts
+++ b/backend/src/schemas.ts
@@ -1,0 +1,41 @@
+import { z } from 'zod';
+
+export const PipelineRequestSchema = z.object({
+  cvText: z.string().min(1, 'cvText is required'),
+  template: z.record(z.string(), z.any()),
+  appLanguage: z.string().default('en'),
+});
+export type PipelineRequest = z.infer<typeof PipelineRequestSchema>;
+
+export const ExtractionSchema = z.record(z.string(), z.any());
+export type Extraction = z.infer<typeof ExtractionSchema>;
+
+export const GapAnalysisSchema = z.object({
+  gaps: z.array(z.string()),
+});
+export type GapAnalysis = z.infer<typeof GapAnalysisSchema>;
+
+export const QuestionsSchema = z.object({
+  questions: z.array(z.string()),
+});
+export type Questions = z.infer<typeof QuestionsSchema>;
+
+export const BulletRewriteSchema = z.object({
+  bullets: z.array(z.string()),
+});
+export type BulletRewrite = z.infer<typeof BulletRewriteSchema>;
+
+export const ScoreSchema = z.object({
+  score: z.number().min(0).max(100),
+  comment: z.string(),
+});
+export type Score = z.infer<typeof ScoreSchema>;
+
+export const PipelineResponseSchema = z.object({
+  extracted: ExtractionSchema,
+  gaps: GapAnalysisSchema,
+  questions: QuestionsSchema,
+  rewritten: BulletRewriteSchema,
+  score: ScoreSchema,
+});
+export type PipelineResponse = z.infer<typeof PipelineResponseSchema>;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,0 +1,21 @@
+import express from 'express';
+import cors from 'cors';
+import helmet from 'helmet';
+import pipelineRouter from './routes/pipeline';
+
+const app = express();
+const port = process.env.PORT || 5001;
+
+app.use(cors());
+app.use(helmet());
+app.use(express.json());
+app.use('/api', pipelineRouter);
+
+app.use((err: Error, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+  console.error(err);
+  res.status(500).json({ error: 'Internal server error' });
+});
+
+app.listen(port, () => {
+  console.log(`server listening on http://localhost:${port}`);
+});

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- add TypeScript server for CV pipeline
- implement JSON-only AI pipeline with extraction, gap analysis, questions, bullet rewrite and scoring
- validate inputs with Zod and limit requests

## Testing
- `npm --prefix backend install`
- `npm --prefix backend run build`
- `npm --prefix backend test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_689c3b7042e88327b6f57228aefa1db4