### PR TITLE
feat: add cv schema and openai utilities

### DIFF
--- a/backend/src/lib/json.ts
+++ b/backend/src/lib/json.ts
@@ -1,0 +1,30 @@
+/**
+ * JSON utilities for safe parsing and cleanup.
+ */
+
+/** Safely parses JSON without throwing */
+export function safeJsonParse<T>(
+  s: string
+): { ok: true; value: T } | { ok: false; error: string } {
+  try {
+    return { ok: true, value: JSON.parse(s) as T };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+/** Forces a string into a JSON object shape */
+export function forceJsonObject(s: string): string {
+  let text = s.trim();
+  text = text.replace(/^```(?:json)?\s*/i, "");
+  text = text.replace(/```$/i, "");
+  const first = text.indexOf("{");
+  const last = text.lastIndexOf("}");
+  if (first !== -1 && last !== -1) {
+    text = text.slice(first, last + 1);
+  }
+  return text;
+}

--- a/backend/src/lib/openai.ts
+++ b/backend/src/lib/openai.ts
@@ -1,0 +1,67 @@
+/**
+ * Single entry point wrapper for OpenAI LLM calls.
+ */
+import OpenAI from "openai";
+import { env } from "../env";
+import { forceJsonObject, safeJsonParse } from "./json";
+
+const client = new OpenAI({ apiKey: env.OPENAI_API_KEY });
+
+export interface CallParams {
+  system: string;
+  user: string;
+  jsonMode?: boolean;
+  temperature?: number;
+  maxTokens?: number;
+}
+
+/** Calls the OpenAI Responses API with optional JSON guardrails */
+export async function callOpenAI<T = unknown>({
+  system,
+  user,
+  jsonMode = true,
+  temperature = 0.2,
+  maxTokens = 800,
+}: CallParams): Promise<T | string> {
+  const baseInput = [
+    { role: "system" as const, content: system },
+    { role: "user" as const, content: user },
+  ];
+
+  let options = {
+    model: "gpt-4o-mini",
+    temperature,
+    max_output_tokens: maxTokens,
+    input: baseInput,
+    response_format: jsonMode ? { type: "json_object" } : undefined,
+  } as const;
+
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 15000);
+    try {
+      const res = await client.responses.create(options, { signal: controller.signal });
+      clearTimeout(timeout);
+      const text = res.output_text ?? "";
+      if (!jsonMode) return text;
+      const forced = forceJsonObject(text);
+      const parsed = safeJsonParse<T>(forced);
+      if (parsed.ok) return parsed.value;
+      // prepare retry prompt
+      options = {
+        ...options,
+        input: [
+          { role: "system", content: system },
+          {
+            role: "user",
+            content: `${user}\nThe previous reply was invalid JSON. Respond with valid JSON only.`,
+          },
+        ],
+      };
+    } catch (err) {
+      clearTimeout(timeout);
+      if (attempt === 1) throw err;
+    }
+  }
+  throw new Error("Failed to produce valid JSON");
+}

--- a/backend/src/schema/api.ts
+++ b/backend/src/schema/api.ts
@@ -1,0 +1,32 @@
+/**
+ * Central API request/response schemas.
+ */
+import { z } from "zod";
+
+// Re-export existing pipeline schemas
+export {
+  PipelineRequestSchema,
+  PipelineResponseSchema,
+  ExtractionSchema,
+  GapAnalysisSchema,
+  QuestionsSchema,
+  BulletRewriteSchema,
+  ScoreSchema,
+} from "../schemas";
+
+export type {
+  PipelineRequest,
+  PipelineResponse,
+  Extraction,
+  GapAnalysis,
+  Questions,
+  BulletRewrite,
+  Score,
+} from "../schemas";
+
+// Placeholders for future endpoint schemas
+export const UploadParseRequestSchema = z.any();
+export const UploadParseResponseSchema = z.any();
+
+export type UploadParseRequest = z.infer<typeof UploadParseRequestSchema>;
+export type UploadParseResponse = z.infer<typeof UploadParseResponseSchema>;

--- a/backend/src/schema/cv.ts
+++ b/backend/src/schema/cv.ts
@@ -1,0 +1,82 @@
+/**
+ * CV schema definition and associated types.
+ */
+import { z } from "zod";
+
+/** YYYY-MM formatted date or null when unknown */
+const DateSchema = z
+  .string()
+  .regex(/^\d{4}-(0[1-9]|1[0-2])$/, "Invalid date format")
+  .nullable();
+
+/** Optional impact metric for bullet points */
+export const ImpactMetricSchema = z.object({
+  type: z.enum(["%", "abs", "time", "money"]),
+  value: z.number(),
+  baseline: z.string().optional(),
+});
+
+/** Single sentence bullet starting with a verb */
+export const BulletSchema = z.object({
+  text: z
+    .string()
+    .min(1)
+    .refine((v) => /^[A-Za-z]/.test(v.trim()), {
+      message: "Bullet must start with a letter",
+    })
+    .refine((v) => v.trim().endsWith("."), {
+      message: "Bullet must end with a period",
+    })
+    .refine((v) => v.replace(/[^.]/g, "").length <= 1, {
+      message: "Bullet must be a single sentence",
+    }),
+  impactMetric: ImpactMetricSchema.optional(),
+});
+
+/** Experience entry */
+export const ExperienceSchema = z.object({
+  role: z.string(),
+  company: z.string(),
+  location: z.string().optional(),
+  startDate: DateSchema,
+  endDate: DateSchema,
+  bullets: z.array(BulletSchema),
+});
+
+/** Education entry */
+export const EducationSchema = z.object({
+  school: z.string(),
+  degree: z.string(),
+  field: z.string().optional(),
+  startDate: DateSchema,
+  endDate: DateSchema,
+});
+
+/** Skills grouped by importance */
+export const SkillsSchema = z.object({
+  primary: z.array(z.string()),
+  secondary: z.array(z.string()),
+  tools: z.array(z.string()),
+});
+
+/** Normalized external links */
+export const LinkSchema = z.object({
+  type: z.enum(["github", "portfolio", "linkedin", "other"]),
+  url: z.string().url(),
+});
+
+/** Main CV schema */
+export const CVSchema = z.object({
+  name: z.string(),
+  email: z.string().email(),
+  phone: z.string().optional(),
+  headline: z.string().optional(),
+  summary: z.string().optional(),
+  location: z.string().optional(),
+  links: z.array(LinkSchema).default([]),
+  skills: SkillsSchema,
+  experience: z.array(ExperienceSchema),
+  education: z.array(EducationSchema),
+});
+
+export type CV = z.infer<typeof CVSchema>;


### PR DESCRIPTION
## Summary
- add CV schema with experience bullets, skill groups, and link types
- provide API schema re-exports and placeholders
- implement JSON helpers and OpenAI wrapper with JSON mode and retry

## Testing
- `npm i zod openai`
- `npx tsc --noEmit && echo tsc_success`


------
https://chatgpt.com/codex/tasks/task_e_689c3e5446a48327862fa38cda4f74ba