### PR TITLE
feat: add CV extractor endpoint

### DIFF
--- a/backend/src/prompts/extract.md
+++ b/backend/src/prompts/extract.md
@@ -1,0 +1,44 @@
+SYSTEM:
+"""
+You are a strict JSON extractor. From resume text, return ONLY valid JSON matching the provided CVSchema.
+No commentary or markdown. Unknown fields -> null. Dates: YYYY-MM. Do not invent facts.
+"""
+
+USER:
+"""
+CVSchema:
+{
+  "name": string,
+  "email": string,
+  "phone": string|null,
+  "headline": string|null,
+  "summary": string|null,
+  "location": string|null,
+  "links": [{ "type": "github|portfolio|linkedin|other", "url": string }],
+  "skills": { "primary": string[], "secondary": string[], "tools": string[] },
+  "experience": [
+    {
+      "role": string,
+      "company": string,
+      "location": string|null,
+      "startDate": "YYYY-MM"|null,
+      "endDate": "YYYY-MM"|null,
+      "bullets": [{ "text": string, "impactMetric": { "type": "%|abs|time|money", "value": number, "baseline": string? }? }]
+    }
+  ],
+  "education": [
+    {
+      "school": string,
+      "degree": string,
+      "field": string|null,
+      "startDate": "YYYY-MM"|null,
+      "endDate": "YYYY-MM"|null
+    }
+  ]
+}
+
+Resume text:
+{{RAW_TEXT}}
+
+Return ONLY the JSON object conforming to CVSchema. If invalid, silently fix formatting and return valid JSON only.
+"""

--- a/backend/src/routes/extract.ts
+++ b/backend/src/routes/extract.ts
@@ -1,0 +1,71 @@
+import { Router } from "express";
+import rateLimit from "express-rate-limit";
+import fs from "fs";
+import path from "path";
+import { callOpenAI } from "../lib/openai";
+import { safeJsonParse } from "../lib/json";
+import { CVSchema } from "../schema/cv";
+import { ExtractRequestSchema } from "../schema/api";
+
+const promptPath = path.join(__dirname, "../prompts/extract.md");
+const promptText = fs.readFileSync(promptPath, "utf8");
+const systemMatch = promptText.match(/SYSTEM:\n"""([\s\S]*?)"""/);
+const userMatch = promptText.match(/USER:\n"""([\s\S]*?)"""/);
+const SYSTEM_PROMPT = systemMatch ? systemMatch[1].trim() : "";
+const USER_TEMPLATE = userMatch ? userMatch[1].trim() : "";
+
+function buildUserPromptFromRawText(rawText: string, targetRole?: string, locale?: "tr" | "en") {
+  let prompt = USER_TEMPLATE.replace("{{RAW_TEXT}}", rawText);
+  if (targetRole) prompt += `\nTarget role: ${targetRole}`;
+  if (locale) prompt += `\nLocale: ${locale}`;
+  return prompt;
+}
+
+const router = Router();
+const limiter = rateLimit({ windowMs: 60_000, max: 5 });
+
+router.post("/", limiter, async (req, res) => {
+  const parsed = ExtractRequestSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res
+      .status(400)
+      .json({ error: "Invalid request", details: parsed.error.format() });
+  }
+
+  const { rawText, targetRole, locale } = parsed.data;
+  const userPrompt = buildUserPromptFromRawText(rawText, targetRole, locale);
+
+  try {
+    const result = await callOpenAI<unknown>({
+      system: SYSTEM_PROMPT,
+      user: userPrompt,
+      jsonMode: true,
+      temperature: 0.2,
+      maxTokens: 1200,
+    });
+
+    let data = result as unknown;
+    // final safety parse if result came back as string for some reason
+    if (typeof result === "string") {
+      const forced = safeJsonParse<unknown>(result);
+      if (!forced.ok) {
+        return res.status(422).json({ error: "Invalid JSON from model" });
+      }
+      data = forced.value;
+    }
+
+    const cvParsed = CVSchema.safeParse(data);
+    if (!cvParsed.success) {
+      return res
+        .status(422)
+        .json({ error: "Invalid CV schema", details: cvParsed.error.format() });
+    }
+
+    res.json({ cv: cvParsed.data });
+  } catch (err) {
+    console.error(err);
+    res.status(422).json({ error: "Extraction failed" });
+  }
+});
+
+export default router;

--- a/backend/src/schema/api.ts
+++ b/backend/src/schema/api.ts
@@ -2,6 +2,7 @@
  * Central API request/response schemas.
  */
 import { z } from "zod";
+import { CVSchema } from "./cv";
 
 // Re-export existing pipeline schemas
 export {
@@ -30,3 +31,17 @@ export const UploadParseResponseSchema = z.any();
 
 export type UploadParseRequest = z.infer<typeof UploadParseRequestSchema>;
 export type UploadParseResponse = z.infer<typeof UploadParseResponseSchema>;
+
+// Extract endpoint schemas
+export const ExtractRequestSchema = z.object({
+  rawText: z.string(),
+  targetRole: z.string().optional(),
+  locale: z.enum(["tr", "en"]).optional(),
+});
+
+export const ExtractResponseSchema = z.object({
+  cv: CVSchema,
+});
+
+export type ExtractRequest = z.infer<typeof ExtractRequestSchema>;
+export type ExtractResponse = z.infer<typeof ExtractResponseSchema>;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import cors from 'cors';
 import helmet from 'helmet';
 import pipelineRouter from './routes/pipeline';
+import extractRouter from './routes/extract';
 
 const app = express();
 const port = process.env.PORT || 5001;
@@ -10,6 +11,7 @@ app.use(cors());
 app.use(helmet());
 app.use(express.json());
 app.use('/api', pipelineRouter);
+app.use('/api/extract', extractRouter);
 
 app.use((err: Error, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
   console.error(err);


### PR DESCRIPTION
## Summary
- add `/api/extract` endpoint for converting raw resume text into structured CVs
- define `ExtractRequest`/`ExtractResponse` schemas and strict JSON extractor prompt
- register extractor route with OpenAI JSON-mode call and validation

## Testing
- `pnpm -C backend add openai zod`
- `pnpm -C backend exec tsc --noEmit`
- `pnpm -C backend run dev` *(fails: Missing script: dev)*
- `pnpm -C backend start` *(fails: Cannot find module 'dist/server.js')*

------
https://chatgpt.com/codex/tasks/task_e_689c411db45c8327a9628b1dd1a400d6