### PR TITLE
feat: add gap analysis endpoint

### DIFF
--- a/backend/src/lib/text.ts
+++ b/backend/src/lib/text.ts
@@ -1,0 +1,17 @@
+/**
+ * Text utilities for simple normalization and keyword extraction.
+ */
+
+const STOPWORDS = new Set([
+  'the','and','for','with','a','an','to','of','in','on','at','or','ve','ile','bir','için'
+]);
+
+/** Normalizes whitespace and removes basic stopwords */
+export function normalizeJobDescription(text: string): string {
+  return text
+    .replace(/\s+/g, ' ')
+    .split(/\s+/)
+    .filter((w) => w && !STOPWORDS.has(w.toLowerCase()))
+    .join(' ')
+    .trim();
+}

--- a/backend/src/prompts/gaps.md
+++ b/backend/src/prompts/gaps.md
@@ -1,0 +1,27 @@
+SYSTEM:
+"""
+You analyze a candidate CV (as CVSchema) against a target role and optional job description.
+Return ONLY valid JSON with:
+{
+  "gaps": [{"type": "...","path":"...","ask":"...","why":"..."}],
+  "missingKeywords": ["..."]
+}
+Rules:
+- "ask" must request one atomic fact the user can quickly answer.
+- Use accurate CVSchema paths.
+- If no meaningful gaps, return {"gaps": [], "missingKeywords": []}.
+- No commentary, no markdown, JSON only.
+"""
+
+USER:
+"""
+Target role: {{TARGET_ROLE}}
+Locale: {{LOCALE}}
+Job Description (optional):
+{{JOB_DESCRIPTION_OR_EMPTY}}
+
+CV (CVSchema JSON):
+{{CV_JSON}}
+
+Return ONLY the JSON as specified. Keep questions concise and actionable.
+"""

--- a/backend/src/routes/gaps.ts
+++ b/backend/src/routes/gaps.ts
@@ -1,0 +1,96 @@
+import { Router } from "express";
+import rateLimit from "express-rate-limit";
+import fs from "fs";
+import path from "path";
+import { callOpenAI } from "../lib/openai";
+import { safeJsonParse } from "../lib/json";
+import { normalizeJobDescription } from "../lib/text";
+import { GapsRequestSchema, GapsResponseSchema } from "../schema/api";
+import type { GapsRequest } from "../schema/api";
+
+const promptPath = path.join(__dirname, "../prompts/gaps.md");
+const promptText = fs.readFileSync(promptPath, "utf8");
+const systemMatch = promptText.match(/SYSTEM:\n"""([\s\S]*?)"""/);
+const userMatch = promptText.match(/USER:\n"""([\s\S]*?)"""/);
+const SYSTEM_PROMPT = systemMatch ? systemMatch[1].trim() : "";
+const USER_TEMPLATE = userMatch ? userMatch[1].trim() : "";
+
+function buildUserPrompt(data: GapsRequest, shorten = false) {
+  const jd = data.jobDescription ? normalizeJobDescription(data.jobDescription) : "";
+  const cvJson = JSON.stringify(data.cv, null, 2);
+  const cvPayload = shorten ? cvJson.slice(0, 2000) : cvJson;
+  return USER_TEMPLATE.replace("{{TARGET_ROLE}}", data.targetRole)
+    .replace("{{LOCALE}}", data.locale)
+    .replace("{{JOB_DESCRIPTION_OR_EMPTY}}", jd)
+    .replace("{{CV_JSON}}", cvPayload);
+}
+
+function pathExists(obj: any, p: string): boolean {
+  const parts = p.replace(/\[(\d+)\]/g, ".$1").split(".");
+  let cur: any = obj;
+  for (const part of parts) {
+    if (part === "") continue;
+    if (Array.isArray(cur)) {
+      const idx = Number(part);
+      if (Number.isNaN(idx) || !(idx in cur)) return false;
+      cur = cur[idx];
+    } else if (cur && typeof cur === "object" && part in cur) {
+      cur = (cur as any)[part];
+    } else {
+      return false;
+    }
+  }
+  return true;
+}
+
+const router = Router();
+const limiter = rateLimit({ windowMs: 60_000, max: 5 });
+
+router.post("/", limiter, async (req, res) => {
+  const parsed = GapsRequestSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res
+      .status(400)
+      .json({ error: "Invalid request", details: parsed.error.format() });
+  }
+
+  const data = parsed.data;
+  let userPrompt = buildUserPrompt(data);
+
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const aiResult = await callOpenAI<unknown>({
+        system: SYSTEM_PROMPT,
+        user: userPrompt,
+        jsonMode: true,
+        temperature: 0.2,
+        maxTokens: 800,
+      });
+
+      let json: unknown = aiResult;
+      if (typeof aiResult === "string") {
+        const forced = safeJsonParse<unknown>(aiResult);
+        if (!forced.ok) {
+          userPrompt = buildUserPrompt(data, true);
+          continue;
+        }
+        json = forced.value;
+      }
+
+      const validated = GapsResponseSchema.safeParse(json);
+      if (!validated.success) {
+        userPrompt = buildUserPrompt(data, true);
+        continue;
+      }
+
+      const validGaps = validated.data.gaps.filter((g) => pathExists(data.cv, g.path));
+      return res.json({ gaps: validGaps, missingKeywords: validated.data.missingKeywords });
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  res.status(422).json({ error: "Gap analysis failed" });
+});
+
+export default router;

--- a/backend/src/schema/api.ts
+++ b/backend/src/schema/api.ts
@@ -45,3 +45,27 @@ export const ExtractResponseSchema = z.object({
 
 export type ExtractRequest = z.infer<typeof ExtractRequestSchema>;
 export type ExtractResponse = z.infer<typeof ExtractResponseSchema>;
+
+// Gaps endpoint schemas
+export const GapsRequestSchema = z.object({
+  cv: CVSchema,
+  targetRole: z.string().min(2),
+  jobDescription: z.string().optional(),
+  locale: z.enum(["tr", "en"]).default("en"),
+});
+
+export const GapItemSchema = z.object({
+  type: z.enum(["MISSING_FIELD", "WEAK_BULLET", "MISSING_KEYWORD"]),
+  path: z.string().min(1),
+  ask: z.string().min(5),
+  why: z.string().optional(),
+});
+
+export const GapsResponseSchema = z.object({
+  gaps: z.array(GapItemSchema),
+  missingKeywords: z.array(z.string()),
+});
+
+export type GapsRequest = z.infer<typeof GapsRequestSchema>;
+export type GapItem = z.infer<typeof GapItemSchema>;
+export type GapsResponse = z.infer<typeof GapsResponseSchema>;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -3,6 +3,7 @@ import cors from 'cors';
 import helmet from 'helmet';
 import pipelineRouter from './routes/pipeline';
 import extractRouter from './routes/extract';
+import gapsRouter from './routes/gaps';
 
 const app = express();
 const port = process.env.PORT || 5001;
@@ -12,6 +13,7 @@ app.use(helmet());
 app.use(express.json());
 app.use('/api', pipelineRouter);
 app.use('/api/extract', extractRouter);
+app.use('/api/gaps', gapsRouter);
 
 app.use((err: Error, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
   console.error(err);


### PR DESCRIPTION
## Summary
- add /api/gaps route to analyze CV gaps and missing keywords
- introduce text normalization helper and gap analysis prompt
- extend API schemas and wire route into server

## Testing
- `pnpm -w -C backend exec tsc --noEmit` *(fails: --workspace-root may only be used inside a workspace)*
- `pnpm -C backend exec tsc --noEmit && echo tsc-ok`
- `pnpm -w -C backend dev` *(fails: --workspace-root may only be used inside a workspace)*
- `pnpm -C backend run dev` *(fails: Missing script: dev)*

------
https://chatgpt.com/codex/tasks/task_e_689c4af6b8208327914f4ceed51b83b2