### PR TITLE
feat: add targeted question generator

### DIFF
--- a/backend/src/lib/id.ts
+++ b/backend/src/lib/id.ts
@@ -1,0 +1,9 @@
+export function stableQuestionId({ path, text }: { path?: string; text: string }): string {
+  const input = `${path ?? ''}|${text}`;
+  let hash = 0x811c9dc5; // FNV-1a 32-bit offset
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(16);
+}

--- a/backend/src/prompts/questions.md
+++ b/backend/src/prompts/questions.md
@@ -1,0 +1,25 @@
+SYSTEM:
+"""
+You generate up to 3 short, single-purpose questions to fill the most impactful information gaps in a CV.
+Input provides a list of gaps (MISSING_FIELD, WEAK_BULLET, MISSING_KEYWORD) and locale.
+Return ONLY valid JSON:
+{"questions":[{"text":"...","expects":"shortText"|"number"|"multi","options"?:string[],"path"?:string}, ...]}
+Rules:
+- Prioritize MISSING_FIELD, then WEAK_BULLET, then MISSING_KEYWORD.
+- Each question must ask for exactly one atomic fact the user can answer quickly.
+- Keep questions concise, avoid jargon. If "multi", include 3–5 options max.
+- If no meaningful questions, return {"questions":[]}.
+- No commentary, no markdown, JSON only.
+"""
+
+USER:
+"""
+Locale: {{LOCALE}}
+
+Gaps:
+{{GAPS_JSON}}
+
+Already asked IDs (do not repeat): {{ALREADY_ASKED_JSON_ARRAY}}
+
+Return ONLY the JSON per the schema above.
+"""

--- a/backend/src/routes/questions.ts
+++ b/backend/src/routes/questions.ts
@@ -1,0 +1,87 @@
+import { Router } from "express";
+import rateLimit from "express-rate-limit";
+import fs from "fs";
+import path from "path";
+import { callOpenAI } from "../lib/openai";
+import { safeJsonParse } from "../lib/json";
+import { stableQuestionId } from "../lib/id";
+import {
+  QuestionsNextRequestSchema,
+  QuestionsNextResponseSchema,
+} from "../schema/api";
+import type { QuestionsNextRequest } from "../schema/api";
+
+const promptPath = path.join(__dirname, "../prompts/questions.md");
+const promptText = fs.readFileSync(promptPath, "utf8");
+const systemMatch = promptText.match(/SYSTEM:\n"""([\s\S]*?)"""/);
+const userMatch = promptText.match(/USER:\n"""([\s\S]*?)"""/);
+const SYSTEM_PROMPT = systemMatch ? systemMatch[1].trim() : "";
+const USER_TEMPLATE = userMatch ? userMatch[1].trim() : "";
+
+function buildUserPrompt(data: QuestionsNextRequest, shorten = false) {
+  const gapsJson = JSON.stringify(data.gaps, null, 2);
+  const gapsPayload = shorten ? gapsJson.slice(0, 2000) : gapsJson;
+  const alreadyJson = JSON.stringify(data.alreadyAsked);
+  return USER_TEMPLATE.replace("{{LOCALE}}", data.locale)
+    .replace("{{GAPS_JSON}}", gapsPayload)
+    .replace("{{ALREADY_ASKED_JSON_ARRAY}}", alreadyJson);
+}
+
+const router = Router();
+const limiter = rateLimit({ windowMs: 60_000, max: 5 });
+
+router.post("/next", limiter, async (req, res) => {
+  const parsed = QuestionsNextRequestSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res
+      .status(400)
+      .json({ error: "Invalid request", details: parsed.error.format() });
+  }
+
+  const data = parsed.data;
+  let userPrompt = buildUserPrompt(data);
+
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const aiResult = await callOpenAI<unknown>({
+        system: SYSTEM_PROMPT,
+        user: userPrompt,
+        jsonMode: true,
+        temperature: 0.2,
+        maxTokens: 500,
+      });
+
+      let json: unknown = aiResult;
+      if (typeof aiResult === "string") {
+        const forced = safeJsonParse<unknown>(aiResult);
+        if (!forced.ok) {
+          userPrompt = buildUserPrompt(data, true);
+          continue;
+        }
+        json = forced.value;
+      }
+
+      const validated = QuestionsNextResponseSchema.safeParse(json);
+      if (!validated.success) {
+        userPrompt = buildUserPrompt(data, true);
+        continue;
+      }
+
+      const alreadySet = new Set(data.alreadyAsked);
+      const processed = validated.data.questions
+        .map((q) => ({ ...q, text: q.text.trim() }))
+        .filter((q) => q.text.length > 0)
+        .map((q) => ({ ...q, id: stableQuestionId({ path: q.path, text: q.text }) }))
+        .filter((q) => !alreadySet.has(q.id))
+        .slice(0, 3);
+
+      return res.json({ questions: processed });
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  res.status(422).json({ error: "Question generation failed" });
+});
+
+export default router;

--- a/backend/src/schema/api.ts
+++ b/backend/src/schema/api.ts
@@ -69,3 +69,35 @@ export const GapsResponseSchema = z.object({
 export type GapsRequest = z.infer<typeof GapsRequestSchema>;
 export type GapItem = z.infer<typeof GapItemSchema>;
 export type GapsResponse = z.infer<typeof GapsResponseSchema>;
+
+// Questions next endpoint schemas
+export const QuestionsNextRequestSchema = z.object({
+  gaps: z
+    .array(
+      z.object({
+        type: z.enum(["MISSING_FIELD", "WEAK_BULLET", "MISSING_KEYWORD"]),
+        path: z.string().min(1),
+        ask: z.string().min(3),
+        why: z.string().optional(),
+      })
+    )
+    .min(1),
+  alreadyAsked: z.array(z.string()).default([]),
+  locale: z.enum(["tr", "en"]).default("en"),
+});
+
+export const QuestionSchema = z.object({
+  id: z.string().min(6),
+  text: z.string().min(3),
+  expects: z.enum(["shortText", "number", "multi"]),
+  options: z.array(z.string()).optional(),
+  path: z.string().optional(),
+});
+
+export const QuestionsNextResponseSchema = z.object({
+  questions: z.array(QuestionSchema).max(3),
+});
+
+export type QuestionsNextRequest = z.infer<typeof QuestionsNextRequestSchema>;
+export type Question = z.infer<typeof QuestionSchema>;
+export type QuestionsNextResponse = z.infer<typeof QuestionsNextResponseSchema>;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -4,6 +4,7 @@ import helmet from 'helmet';
 import pipelineRouter from './routes/pipeline';
 import extractRouter from './routes/extract';
 import gapsRouter from './routes/gaps';
+import questionsRouter from './routes/questions';
 
 const app = express();
 const port = process.env.PORT || 5001;
@@ -14,6 +15,7 @@ app.use(express.json());
 app.use('/api', pipelineRouter);
 app.use('/api/extract', extractRouter);
 app.use('/api/gaps', gapsRouter);
+app.use('/api/questions', questionsRouter);
 
 app.use((err: Error, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
   console.error(err);


### PR DESCRIPTION
## Summary
- add stable question ID hash helper
- implement /api/questions/next endpoint and prompt
- wire up questions route in server

## Testing
- `pnpm -w -C backend exec tsc --noEmit` *(fails: --workspace-root may only be used inside a workspace)*
- `pnpm -C backend exec tsc --noEmit`
- `pnpm -w -C backend dev` *(fails: --workspace-root may only be used inside a workspace)*


------
https://chatgpt.com/codex/tasks/task_e_689c588858fc8327aefa7b26e489f049