### PR TITLE
feat: add bullet rewrite endpoint

### DIFF
--- a/backend/src/lib/quality.ts
+++ b/backend/src/lib/quality.ts
@@ -1,0 +1,74 @@
+// Quality checks and style enforcement for bullet rewriting
+
+export function isSingleSentence(s: string): boolean {
+  const matches = s.trim().match(/[.!?]/g);
+  return !matches || matches.length <= 1;
+}
+
+export function wordCount(s: string): number {
+  return s.trim().split(/\s+/).filter(Boolean).length;
+}
+
+export function changedMeaning(before: string, after: string): boolean {
+  return before.trim().toLowerCase() !== after.trim().toLowerCase();
+}
+
+export function withinLimits(s: string): boolean {
+  return s.length <= 220 && wordCount(s) <= 28;
+}
+
+export function containsFabrication(
+  before: string,
+  after: string,
+  userFacts: string[]
+): boolean {
+  const source = (before + ' ' + userFacts.join(' ')).toLowerCase();
+  const allowed = new Set(source.match(/[a-z0-9%]+/gi) ?? []);
+  const tokens = after.match(/[a-z0-9%]+/gi) ?? [];
+  for (const t of tokens) {
+    const lower = t.toLowerCase();
+    if (!allowed.has(lower)) {
+      if (/\d/.test(t) || /^[A-Z]/.test(t)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+export function enforceStyle(after: string, locale: 'en' | 'tr'): string {
+  let s = after.trim();
+  if (locale === 'en') {
+    s = s.replace(/^(I|We)\s+/i, '');
+    const map: Record<string, string> = {
+      Worked: 'Built',
+      Was: 'Led',
+      Did: 'Completed',
+      Made: 'Created',
+      Responsible: 'Led',
+    };
+    for (const [weak, strong] of Object.entries(map)) {
+      const r = new RegExp(`^${weak}\\b`, 'i');
+      if (r.test(s)) {
+        s = s.replace(r, strong);
+        break;
+      }
+    }
+  } else {
+    s = s.replace(/^(Ben|Biz)\s+/i, '');
+    const map: Record<string, string> = {
+      Çalıştım: 'Geliştirdim',
+      Yaptım: 'Gerçekleştirdim',
+      Sorumluydum: 'Yönettim',
+    };
+    for (const [weak, strong] of Object.entries(map)) {
+      const r = new RegExp(`^${weak}\\b`, 'i');
+      if (r.test(s)) {
+        s = s.replace(r, strong);
+        break;
+      }
+    }
+  }
+  if (s.length === 0) return after;
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}

--- a/backend/src/prompts/rewrite_bullet.md
+++ b/backend/src/prompts/rewrite_bullet.md
@@ -1,0 +1,31 @@
+SYSTEM:
+"""
+You rewrite a single resume bullet using ONLY the allowed sources:
+- before: original bullet text
+- userFacts: extra facts provided by the user (numbers, scope, tools, outcomes)
+- optional: targetRole/jobDescription for vocabulary alignment (NO new facts)
+
+Rules:
+- One sentence, start with a strong action verb.
+- Include a measurable impact if and only if userFacts provide numbers; never invent metrics.
+- No new companies, titles, dates, or technologies not present in before or userFacts.
+- Keep it concise (<= 28 words and <= 220 characters), no fluff/jargon.
+- Return ONLY valid JSON: {"before":"...","after":"...","rationale":"..."}.
+"""
+
+USER:
+"""
+Locale: {{LOCALE}}
+Target role: {{TARGET_ROLE_OR_EMPTY}}
+Job Description (optional):
+{{JOB_DESCRIPTION_OR_EMPTY}}
+
+Before:
+{{BEFORE_BULLET}}
+
+UserFacts (authoritative, do NOT invent beyond these):
+{{USER_FACTS_JSON_ARRAY}}
+
+Return ONLY:
+{"before":"(same as input)","after":"(single improved sentence)","rationale":"(<= 20 words)"}
+"""

--- a/backend/src/routes/rewrite.ts
+++ b/backend/src/routes/rewrite.ts
@@ -1,0 +1,109 @@
+import { Router } from 'express';
+import rateLimit from 'express-rate-limit';
+import fs from 'fs';
+import path from 'path';
+import { callOpenAI } from '../lib/openai';
+import { safeJsonParse } from '../lib/json';
+import {
+  RewriteBulletRequestSchema,
+  RewriteBulletResponseSchema,
+  RewriteBulletRequest,
+} from '../schema/api';
+import {
+  isSingleSentence,
+  withinLimits,
+  changedMeaning,
+  containsFabrication,
+  enforceStyle,
+} from '../lib/quality';
+
+const promptPath = path.join(__dirname, '../prompts/rewrite_bullet.md');
+const promptText = fs.readFileSync(promptPath, 'utf8');
+const systemMatch = promptText.match(/SYSTEM:\n"""([\s\S]*?)"""/);
+const userMatch = promptText.match(/USER:\n"""([\s\S]*?)"""/);
+const SYSTEM_PROMPT = systemMatch ? systemMatch[1].trim() : '';
+const USER_TEMPLATE = userMatch ? userMatch[1].trim() : '';
+
+function buildUserPrompt(data: RewriteBulletRequest, note = '') {
+  const factsJson = JSON.stringify(data.userFacts, null, 2);
+  return USER_TEMPLATE.replace('{{LOCALE}}', data.locale)
+    .replace('{{TARGET_ROLE_OR_EMPTY}}', data.targetRole ?? '')
+    .replace('{{JOB_DESCRIPTION_OR_EMPTY}}', data.jobDescription ?? '')
+    .replace('{{BEFORE_BULLET}}', data.before)
+    .replace('{{USER_FACTS_JSON_ARRAY}}', factsJson)
+    .concat(note ? `\n${note}` : '');
+}
+
+const router = Router();
+const limiter = rateLimit({ windowMs: 60_000, max: 5 });
+
+router.post('/bullet', limiter, async (req, res) => {
+  const parsed = RewriteBulletRequestSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res
+      .status(400)
+      .json({ error: 'Invalid request', details: parsed.error.format() });
+  }
+  const data = parsed.data;
+  let userPrompt = buildUserPrompt(data);
+
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const aiResult = await callOpenAI<unknown>({
+        system: SYSTEM_PROMPT,
+        user: userPrompt,
+        jsonMode: true,
+        temperature: 0.2,
+        maxTokens: 300,
+      });
+
+      let json: unknown = aiResult;
+      if (typeof aiResult === 'string') {
+        const forced = safeJsonParse<unknown>(aiResult);
+        if (!forced.ok) {
+          userPrompt = buildUserPrompt(data, '\nReturn ONLY valid JSON.');
+          continue;
+        }
+        json = forced.value;
+      }
+
+      const validated = RewriteBulletResponseSchema.safeParse(json);
+      if (!validated.success) {
+        userPrompt = buildUserPrompt(data, '\nReturn ONLY valid JSON.');
+        continue;
+      }
+
+      let styled = enforceStyle(validated.data.after.trim(), data.locale);
+
+      if (
+        !isSingleSentence(styled) ||
+        !withinLimits(styled) ||
+        !changedMeaning(data.before, styled)
+      ) {
+        return res.status(422).json({ error: 'Quality check failed' });
+      }
+
+      if (containsFabrication(data.before, styled, data.userFacts)) {
+        if (attempt === 0) {
+          userPrompt = buildUserPrompt(
+            data,
+            '\nYour previous answer added unverified details. Use ONLY provided facts and avoid numbers if none supplied.'
+          );
+          continue;
+        }
+        return res.status(422).json({ error: 'Possible fabrication detected' });
+      }
+
+      return res.json({
+        before: data.before,
+        after: styled,
+        rationale: validated.data.rationale,
+      });
+    } catch (err) {
+      console.error(err);
+    }
+  }
+  res.status(422).json({ error: 'Rewrite failed' });
+});
+
+export default router;

--- a/backend/src/schema/api.ts
+++ b/backend/src/schema/api.ts
@@ -101,3 +101,21 @@ export const QuestionsNextResponseSchema = z.object({
 export type QuestionsNextRequest = z.infer<typeof QuestionsNextRequestSchema>;
 export type Question = z.infer<typeof QuestionSchema>;
 export type QuestionsNextResponse = z.infer<typeof QuestionsNextResponseSchema>;
+
+// Rewrite bullet endpoint schemas
+export const RewriteBulletRequestSchema = z.object({
+  before: z.string().min(3),
+  userFacts: z.array(z.string()).default([]),
+  targetRole: z.string().optional(),
+  jobDescription: z.string().optional(),
+  locale: z.enum(["tr", "en"]).default("en"),
+});
+
+export const RewriteBulletResponseSchema = z.object({
+  before: z.string().min(3),
+  after: z.string().min(3),
+  rationale: z.string().max(140).optional(),
+});
+
+export type RewriteBulletRequest = z.infer<typeof RewriteBulletRequestSchema>;
+export type RewriteBulletResponse = z.infer<typeof RewriteBulletResponseSchema>;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -5,6 +5,7 @@ import pipelineRouter from './routes/pipeline';
 import extractRouter from './routes/extract';
 import gapsRouter from './routes/gaps';
 import questionsRouter from './routes/questions';
+import rewriteRouter from './routes/rewrite';
 
 const app = express();
 const port = process.env.PORT || 5001;
@@ -16,6 +17,7 @@ app.use('/api', pipelineRouter);
 app.use('/api/extract', extractRouter);
 app.use('/api/gaps', gapsRouter);
 app.use('/api/questions', questionsRouter);
+app.use('/api/rewrite', rewriteRouter);
 
 app.use((err: Error, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
   console.error(err);


### PR DESCRIPTION
## Summary
- add rewrite bullet endpoint with OpenAI prompt and validation
- implement quality guards for sentence length, style, and fabrication
- register rewrite route and schemas

## Testing
- `pnpm -w -C backend exec tsc --noEmit` *(fails: --workspace-root may only be used inside a workspace)*
- `pnpm -C backend exec tsc --noEmit`
- `pnpm -w -C backend dev` *(fails: --workspace-root may only be used inside a workspace)*

------
https://chatgpt.com/codex/tasks/task_e_689c6645d2bc8327b7fedaa8246043f6