### PR TITLE
feat: add CV scoring endpoint with ATS and role-fit analysis

### DIFF
--- a/backend/src/lib/ats.ts
+++ b/backend/src/lib/ats.ts
@@ -1,0 +1,154 @@
+import { CV } from "../schema/cv";
+
+export interface Issue {
+  path?: string;
+  message: string;
+}
+
+interface AtsContext {
+  targetRole: string;
+  jobDescription?: string;
+}
+
+interface AtsResult {
+  score: number;
+  issues: Issue[];
+}
+
+const DATE_RE = /^\d{4}-(0[1-9]|1[0-2])$/;
+const URL_RE = /^https?:\/\//i;
+const EMAIL_RE = /^[^@\s]+@[^@\s]+\.[^@\s]+$/;
+const PHONE_RE = /^\+?[0-9\s-]{7,15}$/;
+
+function checkDates(cv: CV): Issue[] {
+  const issues: Issue[] = [];
+  cv.experience.forEach((exp, i) => {
+    if (!exp.startDate || !DATE_RE.test(exp.startDate)) {
+      issues.push({ path: `experience[${i}].startDate`, message: "Invalid date format" });
+    }
+    if (exp.endDate && !DATE_RE.test(exp.endDate)) {
+      issues.push({ path: `experience[${i}].endDate`, message: "Invalid date format" });
+    }
+    if (exp.startDate && exp.endDate && exp.endDate < exp.startDate) {
+      issues.push({ path: `experience[${i}].endDate`, message: "End date before start date" });
+    }
+  });
+  cv.education.forEach((ed, i) => {
+    if (!ed.startDate || !DATE_RE.test(ed.startDate)) {
+      issues.push({ path: `education[${i}].startDate`, message: "Invalid date format" });
+    }
+    if (ed.endDate && !DATE_RE.test(ed.endDate)) {
+      issues.push({ path: `education[${i}].endDate`, message: "Invalid date format" });
+    }
+    if (ed.startDate && ed.endDate && ed.endDate < ed.startDate) {
+      issues.push({ path: `education[${i}].endDate`, message: "End date before start date" });
+    }
+  });
+  return issues;
+}
+
+function checkBullets(cv: CV): Issue[] {
+  const issues: Issue[] = [];
+  cv.experience.forEach((exp, i) => {
+    exp.bullets.forEach((b, j) => {
+      const words = b.text.trim().split(/\s+/).length;
+      if (words > 28 || b.text.length > 220) {
+        issues.push({ path: `experience[${i}].bullets[${j}]`, message: "Bullet too long" });
+      }
+      if (!b.text.trim().endsWith('.')) {
+        issues.push({ path: `experience[${i}].bullets[${j}]`, message: "Bullet should end with a period" });
+      }
+    });
+  });
+  return issues;
+}
+
+function checkRequired(cv: CV): Issue[] {
+  const issues: Issue[] = [];
+  if (!cv.summary || cv.summary.trim() === '') {
+    issues.push({ path: 'summary', message: 'Missing professional summary' });
+  }
+  if (!cv.experience || cv.experience.length === 0) {
+    issues.push({ path: 'experience', message: 'Experience section is empty' });
+  }
+  const skillCount = cv.skills.primary.length + cv.skills.secondary.length + cv.skills.tools.length;
+  if (skillCount === 0) {
+    issues.push({ path: 'skills', message: 'Skills section is empty' });
+  }
+  return issues;
+}
+
+function checkLinks(cv: CV): Issue[] {
+  const issues: Issue[] = [];
+  cv.links.forEach((link, i) => {
+    if (!URL_RE.test(link.url)) {
+      issues.push({ path: `links[${i}].url`, message: 'Invalid link URL' });
+    }
+  });
+  return issues;
+}
+
+function checkContacts(cv: CV): Issue[] {
+  const issues: Issue[] = [];
+  if (!EMAIL_RE.test(cv.email)) {
+    issues.push({ path: 'email', message: 'Invalid email format' });
+  }
+  if (cv.phone && !PHONE_RE.test(cv.phone)) {
+    issues.push({ path: 'phone', message: 'Invalid phone number format' });
+  }
+  return issues;
+}
+
+function checkKeywords(cv: CV, ctx: AtsContext): Issue[] {
+  const text = JSON.stringify(cv).toLowerCase();
+  const source = (ctx.jobDescription || ctx.targetRole).toLowerCase();
+  const tokens = Array.from(new Set(source.match(/[a-zA-Z][a-zA-Z0-9+#\.\-]{2,}/g) || []));
+  const missing = tokens.filter((t) => !text.includes(t));
+  if (missing.length === 0) return [];
+  return [
+    {
+      message: `Missing keywords: ${missing.slice(0, 5).join(', ')}`,
+    },
+  ];
+}
+
+export function runAtsChecks(cv: CV, ctx: AtsContext): AtsResult {
+  const weights = {
+    required: 20,
+    dates: 20,
+    bullets: 15,
+    links: 10,
+    contacts: 10,
+    keywords: 25,
+  } as const;
+
+  const issues: Issue[] = [];
+  let score = 0;
+
+  const req = checkRequired(cv);
+  if (req.length === 0) score += weights.required; else issues.push(...req);
+
+  const dates = checkDates(cv);
+  if (dates.length === 0) score += weights.dates; else issues.push(...dates);
+
+  const bullets = checkBullets(cv);
+  if (bullets.length === 0) score += weights.bullets; else issues.push(...bullets);
+
+  const links = checkLinks(cv);
+  if (links.length === 0) score += weights.links; else issues.push(...links);
+
+  const contacts = checkContacts(cv);
+  if (contacts.length === 0) score += weights.contacts; else issues.push(...contacts);
+
+  const keywords = checkKeywords(cv, ctx);
+  if (keywords.length === 0) score += weights.keywords; else issues.push(...keywords);
+
+  return { score, issues };
+}
+
+export function deriveFixHints(issues: Issue[], reasons: string[]): string[] {
+  const hints = new Set<string>();
+  issues.forEach((i) => hints.add(i.message));
+  reasons.forEach((r) => hints.add(r));
+  return Array.from(hints);
+}

--- a/backend/src/prompts/rolefit.md
+++ b/backend/src/prompts/rolefit.md
@@ -1,0 +1,21 @@
+SYSTEM:
+"""
+You assess role fit for a CV.
+Return ONLY valid JSON: {"roleFitScore":0-100,"reasons":["...","..."]}.
+Rules:
+- Use only the provided CVSchema JSON, targetRole and optional jobDescription.
+- No prose, no markdown, JSON only.
+"""
+
+USER:
+"""
+Target role: {{TARGET_ROLE}}
+Locale: {{LOCALE}}
+Job Description (optional):
+{{JOB_DESCRIPTION_OR_EMPTY}}
+
+CV (CVSchema JSON):
+{{CV_JSON}}
+
+Return ONLY: {"roleFitScore": number, "reasons": string[]}
+"""

--- a/backend/src/routes/score.ts
+++ b/backend/src/routes/score.ts
@@ -1,0 +1,86 @@
+import { Router } from "express";
+import rateLimit from "express-rate-limit";
+import fs from "fs";
+import path from "path";
+import { z } from "zod";
+import { callOpenAI } from "../lib/openai";
+import { safeJsonParse } from "../lib/json";
+import { runAtsChecks, deriveFixHints } from "../lib/ats";
+import { ScoreRequestSchema } from "../schema/api";
+import type { ScoreRequest } from "../schema/api";
+
+const promptPath = path.join(__dirname, "../prompts/rolefit.md");
+const promptText = fs.readFileSync(promptPath, "utf8");
+const systemMatch = promptText.match(/SYSTEM:\n"""([\s\S]*?)"""/);
+const userMatch = promptText.match(/USER:\n"""([\s\S]*?)"""/);
+const SYSTEM_PROMPT = systemMatch ? systemMatch[1].trim() : "";
+const USER_TEMPLATE = userMatch ? userMatch[1].trim() : "";
+
+function buildUserPrompt(data: ScoreRequest) {
+  const cvJson = JSON.stringify(data.cv, null, 2);
+  const jd = data.jobDescription || "";
+  return USER_TEMPLATE.replace("{{TARGET_ROLE}}", data.targetRole)
+    .replace("{{LOCALE}}", data.locale)
+    .replace("{{JOB_DESCRIPTION_OR_EMPTY}}", jd)
+    .replace("{{CV_JSON}}", cvJson);
+}
+
+const RoleFitSchema = z.object({
+  roleFitScore: z.number().min(0).max(100),
+  reasons: z.array(z.string()),
+});
+
+const router = Router();
+const limiter = rateLimit({ windowMs: 60_000, max: 5 });
+
+router.post("/", limiter, async (req, res) => {
+  const parsed = ScoreRequestSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: "Invalid request", details: parsed.error.format() });
+  }
+  const data = parsed.data;
+
+  const ats = runAtsChecks(data.cv, { targetRole: data.targetRole, jobDescription: data.jobDescription });
+
+  let roleFitScore = 50;
+  let reasons: string[] = [];
+  const userPrompt = buildUserPrompt(data);
+
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const ai = await callOpenAI<{ roleFitScore: number; reasons: string[] }>({
+        system: SYSTEM_PROMPT,
+        user: userPrompt,
+        jsonMode: true,
+        temperature: 0.2,
+        maxTokens: 300,
+      });
+
+      let json: any = ai;
+      if (typeof ai === "string") {
+        const parsedAi = safeJsonParse<{ roleFitScore: number; reasons: string[] }>(ai);
+        if (!parsedAi.ok) continue;
+        json = parsedAi.value;
+      }
+      const valid = RoleFitSchema.safeParse(json);
+      if (!valid.success) continue;
+      roleFitScore = valid.data.roleFitScore;
+      reasons = valid.data.reasons;
+      break;
+    } catch (err) {
+      if (attempt === 1) {
+        console.error(err);
+      }
+    }
+  }
+
+  const fixHints = deriveFixHints(ats.issues, reasons);
+  return res.json({
+    atsScore: ats.score,
+    roleFitScore,
+    issues: ats.issues,
+    fixHints,
+  });
+});
+
+export default router;

--- a/backend/src/schema/api.ts
+++ b/backend/src/schema/api.ts
@@ -119,3 +119,21 @@ export const RewriteBulletResponseSchema = z.object({
 
 export type RewriteBulletRequest = z.infer<typeof RewriteBulletRequestSchema>;
 export type RewriteBulletResponse = z.infer<typeof RewriteBulletResponseSchema>;
+
+// Score endpoint schemas
+export const ScoreRequestSchema = z.object({
+  cv: CVSchema,
+  targetRole: z.string().min(2),
+  jobDescription: z.string().optional(),
+  locale: z.enum(["tr", "en"]).default("en"),
+});
+
+export const ScoreResponseSchema = z.object({
+  atsScore: z.number().min(0).max(100),
+  roleFitScore: z.number().min(0).max(100),
+  issues: z.array(z.object({ path: z.string().optional(), message: z.string().min(3) })),
+  fixHints: z.array(z.string()),
+});
+
+export type ScoreRequest = z.infer<typeof ScoreRequestSchema>;
+export type ScoreResponse = z.infer<typeof ScoreResponseSchema>;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -6,6 +6,7 @@ import extractRouter from './routes/extract';
 import gapsRouter from './routes/gaps';
 import questionsRouter from './routes/questions';
 import rewriteRouter from './routes/rewrite';
+import scoreRouter from './routes/score';
 
 const app = express();
 const port = process.env.PORT || 5001;
@@ -18,6 +19,7 @@ app.use('/api/extract', extractRouter);
 app.use('/api/gaps', gapsRouter);
 app.use('/api/questions', questionsRouter);
 app.use('/api/rewrite', rewriteRouter);
+app.use('/api/score', scoreRouter);
 
 app.use((err: Error, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
   console.error(err);


### PR DESCRIPTION
## Summary
- implement score request/response schemas
- add ats rule engine and role-fit prompt
- introduce /api/score route and register on server

## Testing
- `pnpm -w -C backend exec tsc --noEmit` *(fails: --workspace-root may only be used inside a workspace)*
- `pnpm -w -C backend dev` *(fails: --workspace-root may only be used inside a workspace)*

------
https://chatgpt.com/codex/tasks/task_e_689c6c590a5483279d80a8e6f4601474